### PR TITLE
When specifying --noBN, use _nobn discriminator network as well

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,11 +116,14 @@ if opt.netG != '': # load checkpoint if needed
     netG.load_state_dict(torch.load(opt.netG))
 print(netG)
 
-if opt.mlp_D:
+if opt.noBN:
+    netD = dcgan.DCGAN_D_nobn(opt.imageSize, nz, nc, ndf, ngpu, n_extra_layers)
+elif opt.mlp_D:
     netD = mlp.MLP_D(opt.imageSize, nz, nc, ndf, ngpu)
 else:
     netD = dcgan.DCGAN_D(opt.imageSize, nz, nc, ndf, ngpu, n_extra_layers)
-    netD.apply(weights_init)
+
+netD.apply(weights_init)
 
 if opt.netD != '':
     netD.load_state_dict(torch.load(opt.netD))


### PR DESCRIPTION
Was this deliberate? When passing the --noBN flag, the discriminator network still uses batchnorms, despite the fact that a batchnorm-less network is specified in dcgan.py. Pull fixes this.