### PR TITLE
Make sure the generator training always gets a full batch of noise

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,6 +203,9 @@ for epoch in range(opt.niter):
         for p in netD.parameters():
             p.requires_grad = False # to avoid computation
         netG.zero_grad()
+        # in case our last batch was the tail batch of the dataloader,
+        # make sure we feed a full batch of noise
+        noise.data.resize_(opt.batchSize, nz, 1, 1)
         noise.data.normal_(0, 1)
         fake = netG(noise)
         errG = netD(fake)


### PR DESCRIPTION
With small libraries of images we will semi-often be in the situation where we're proceeding to the generator training step because we ran out of images in the discriminator training. In these cases, we leave the noise variable in the state it was in for the last discriminator training step, which may be a very small number of images. (Consider a batch size of 64 and say, 130 images.) This occasionally leads to a too-small batch size in the generator training step. Fix this by resetting the noise to the parameter batchSize before training the generator.

Have a tiny diff :)