### PR TITLE
set noisev to Volatile to freeze netG when updating netD.

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,10 +190,9 @@ for epoch in range(opt.niter):
 
             # train with fake
             noise.resize_(opt.batchSize, nz, 1, 1).normal_(0, 1)
-            noisev = Variable(noise)
-            fake = netG(noisev)
+            noisev = Variable(noise, volatile = True) # totally freeze netG
+            fake = Variable(netG(noisev).data)
             inputv = fake
-            inputv.detach()
             errD_fake = netD(inputv)
             errD_fake.backward(mone)
             errD = errD_real - errD_fake


### PR DESCRIPTION
when training netD, we won't need the gradient and buffer of netG. set noisev to `volatile` would acclerate training step and reduce memory usage which is even better than `detach`.

