### PR TITLE
Fixing wrong variable name

### DIFF
--- a/models/mlp.py
+++ b/models/mlp.py
@@ -31,7 +31,7 @@ class MLP_G(nn.Module):
             output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
         else:
             output = self.main(input)
-        return output.view(out.size(0), self.nc, self.isize, self.isize)
+        return output.view(output.size(0), self.nc, self.isize, self.isize)
 
 
 class MLP_D(nn.Module):


### PR DESCRIPTION
There is no variable called `out`; the code produces an error if you try to run it. Given the history of the file, it seems that the variable should be `output`.